### PR TITLE
Porting to dune

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,13 @@
+(executable
+ (modes byte exe)
+ (name main)
+ (public_name jbuild-pp)
+ (libraries cmdliner containers result))
+
+(rule
+ (alias runtest)
+ (deps
+  (:< main.exe)
+  dune)
+ (action
+  (run %{<} dune)))

--- a/dune
+++ b/dune
@@ -1,17 +1,22 @@
 (executable
- (modes byte exe)
- (name main)
- (public_name jbuild-pp)
- (libraries
-  cmdliner
-  containers
-  result))
+  (modes byte exe)
+  (name main)
+  (public_name jbuild-pp)
+  (libraries
+    cmdliner
+    containers
+    result
+  )
+)
 
 (rule
- (alias runtest)
- (deps
-  (:< main.exe)
-  dune)
- (action
-  (run %{<} dune)))
+  (alias runtest)
+  (deps
+    (:< main.exe)
+    dune
+  )
+  (action
+    (run %{<} dune)
+  )
+)
 

--- a/dune
+++ b/dune
@@ -2,7 +2,10 @@
  (modes byte exe)
  (name main)
  (public_name jbuild-pp)
- (libraries cmdliner containers result))
+ (libraries
+  cmdliner
+  containers
+  result))
 
 (rule
  (alias runtest)
@@ -11,3 +14,4 @@
   dune)
  (action
   (run %{<} dune)))
+

--- a/pretty.ml
+++ b/pretty.ml
@@ -23,7 +23,7 @@ let rec pp fmt = function
   | `List (`Atom _ :: `List _ :: _ as l) ->
     Format.fprintf fmt "@[<v2>(";
     pp' fmt l;
-    Format.fprintf fmt ")@]"
+    Format.fprintf fmt "@]@,)"
   | `List ((`List _ :: _ :: _) as l) ->
     Format.fprintf fmt "@[<v2>(";
     pp' fmt l;

--- a/pretty.ml
+++ b/pretty.ml
@@ -21,15 +21,15 @@ let rec pp fmt = function
   | `List [x] -> Format.fprintf fmt "@[<hov2>(%a)@]" pp x
   | `List (`Atom ("libraries") :: _ as l)
   | `List (`Atom _ :: `List _ :: _ as l) ->
-    Format.fprintf fmt "@[<v1>(";
+    Format.fprintf fmt "@[<v2>(";
     pp' fmt l;
     Format.fprintf fmt ")@]"
   | `List ((`List _ :: _ :: _) as l) ->
-    Format.fprintf fmt "@[<v1>(";
+    Format.fprintf fmt "@[<v2>(";
     pp' fmt l;
     Format.fprintf fmt ")@]"
   | `List l ->
-    Format.fprintf fmt "@[<hov1>(";
+    Format.fprintf fmt "@[<hov2>(";
     pp' fmt l;
     Format.fprintf fmt ")@]"
 

--- a/pretty.ml
+++ b/pretty.ml
@@ -19,7 +19,8 @@ let rec pp fmt = function
   | `Atom s   -> Format.pp_print_string fmt s
   | `List []  -> Format.pp_print_string fmt "()"
   | `List [x] -> Format.fprintf fmt "@[<hov2>(%a)@]" pp x
-  | `List ([`Atom _; `List _] as l) ->
+  | `List (`Atom ("libraries") :: _ as l)
+  | `List (`Atom _ :: `List _ :: _ as l) ->
     Format.fprintf fmt "@[<v1>(";
     pp' fmt l;
     Format.fprintf fmt ")@]"


### PR DESCRIPTION
Nesting changed, and we want libraries on a separate line, this is addressed in this PR.

However the rule line still looks wrong:

```
(executable          
 (modes byte exe)
 (name main)
 (public_name jbuild-pp)
 (libraries
  cmdliner
  containers
  result))

(rule (alias runtest) (deps
                       (:< main.exe)
                       dune) (action
                              (run %{<} dune)))
```